### PR TITLE
chore: 깃허브 리뷰어 제한(#12)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @wnsgho @GGICK @gomsbft


### PR DESCRIPTION
- 깃허브 리뷰어로 organizatino에 있는 모든 사람 지정이 가능해서 repository에 있는 사람만 리뷰어로 뜨도록 제한했습니다.

close #11 