### PR TITLE
design: 헤더 퍼블리싱 작업(#14)

### DIFF
--- a/public/side.svg
+++ b/public/side.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="28px" viewBox="0 -960 960 960" width="28px" fill="#7F5546"><path d="M120-240v-80h720v80H120Zm0-200v-80h720v80H120Zm0-200v-80h720v80H120Z"/></svg>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import { Link, useLocation } from "react-router-dom";
+
+const Header = () => {
+  const location = useLocation(); 
+
+  // 로그인 페이지인지 회원가입 페이지인지 구별하기
+  const isLoginPage = location.pathname === "/login";
+  const isSignupPage = location.pathname === "/signup";
+
+  return (
+    <header className="flex items-center justify-between px-10 py-6 bg-white shadow-md">
+      {/* TENPAWS */}
+      <div className="text-4xl font-bold" style={{ color: "#7F5546" }}>
+        TenPaws
+      </div>
+
+      {/* 매칭, 안내, 내정보 */}
+      <nav className="flex gap-60 text-3xl font-medium">
+        <span>매칭</span>
+        <span>안내</span>
+        <span>내정보</span>
+      </nav>
+
+      {/* 로그인/ 회원가입 */}
+      <div className="text-2xl font-medium">
+        {isLoginPage || isSignupPage ? (
+          // 로그인 페이지가 아닌 경우 헤더 오른쪽을 로그인으로 설정
+          <Link to="/signup" className="hover:text-gray-700">
+            로그인
+          </Link>
+        ) : (
+          // 로그인 페이지인 경우 헤더 오른쪽을 회원가입으로 설정
+          <Link to="/login" className="hover:text-gray-700">
+            회원가입
+          </Link>
+        )}
+      </div>
+    </header>
+  );
+};
+
+export default Header;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -31,7 +31,7 @@ const Header = () => {
         )}
       </div>
 
-      {/* 모바일 헤더 */}
+      {/* 모바일 화면(헤더 및 아이콘) */}
       <div className="md:hidden flex flex-1 justify-end">
         {/* 사이드 아이콘 */}
         <img

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Link, useLocation } from "react-router-dom";
 
 const Header = () => {
-  const location = useLocation(); 
+  const location = useLocation();
 
   // 로그인 페이지인지 회원가입 페이지인지 구별하기
   const isLoginPage = location.pathname === "/login";
@@ -16,7 +16,7 @@ const Header = () => {
       </div>
 
       {/* 매칭, 안내, 내정보 */}
-      <nav className="flex gap-60 text-3xl font-medium">
+      <nav className="hidden md:flex flex-1 justify-center items-center gap-16 lg:gap-32 xl:gap-60 text-3xl font-medium">
         <span>매칭</span>
         <span>안내</span>
         <span>내정보</span>
@@ -35,6 +35,15 @@ const Header = () => {
             회원가입
           </Link>
         )}
+      </div>
+
+      {/* 모바일 화면(헤더 및 아이콘) */}
+      <div className="md:hidden">
+        <img
+          src="/side.svg"
+          alt="Side menu"
+          className="w-12 h-12 cursor-pointer"
+        />
       </div>
     </header>
   );

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Link, useLocation } from "react-router-dom";
+import { useLocation } from "react-router-dom";
 
 const Header = () => {
   const location = useLocation();
@@ -22,23 +22,18 @@ const Header = () => {
         <span>내정보</span>
       </nav>
 
-      {/* 로그인/ 회원가입 */}
-      <div className="text-2xl font-medium">
+      {/* 로그인 / 회원가입 */}
+      <div className="hidden md:block text-2xl font-medium">
         {isLoginPage || isSignupPage ? (
-          // 로그인 페이지가 아닌 경우 헤더 오른쪽을 로그인으로 설정
-          <Link to="/signup" className="hover:text-gray-700">
-            로그인
-          </Link>
+          <span className="hover:text-gray-700">로그인</span>
         ) : (
-          // 로그인 페이지인 경우 헤더 오른쪽을 회원가입으로 설정
-          <Link to="/login" className="hover:text-gray-700">
-            회원가입
-          </Link>
+          <span className="hover:text-gray-700">회원가입</span>
         )}
       </div>
 
-      {/* 모바일 화면(헤더 및 아이콘) */}
-      <div className="md:hidden">
+      {/* 모바일 헤더 */}
+      <div className="md:hidden flex flex-1 justify-end">
+        {/* 사이드 아이콘 */}
         <img
           src="/side.svg"
           alt="Side menu"


### PR DESCRIPTION
- 헤더 퍼블리싱 작업(로그인 페이지의 경우 헤더 오른쪽을 회원가입으로 변경)
<img width="1390" alt="스크린샷 2024-11-21 오후 2 34 59" src="https://github.com/user-attachments/assets/29c50f70-55ad-4f86-ae85-59d8a5e7d947">
<img width="1397" alt="스크린샷 2024-11-21 오후 2 36 35" src="https://github.com/user-attachments/assets/3e6db47e-9ba3-4363-9754-9ae10fbcef08">
<img width="529" alt="스크린샷 2024-11-21 오후 4 01 44" src="https://github.com/user-attachments/assets/33cd1ad1-3bc5-43de-8147-fb86f76f616b">
